### PR TITLE
Fix ros and socket conflict

### DIFF
--- a/bin/node.py
+++ b/bin/node.py
@@ -22,9 +22,7 @@ def main():
     if adapter == 'dira':
         simulator.set_adapter(DiRASimAdapter(simulator))
     if adapter == 'uit':
-        uit_adapter = UITSimAdapter(simulator)
-        simulator.set_adapter(uit_adapter)
-        eventlet.wsgi.server(uit_adapter.listen, uit_adapter.app)
+        simulator.set_adapter(UITSimAdapter(simulator))
 
     simulator.run_loop()
 

--- a/src/sim_adapter/uit_adapter.py
+++ b/src/sim_adapter/uit_adapter.py
@@ -30,11 +30,13 @@ class UITSimAdapter(SimAdapter):
         self.sio.on('telemetry', self.telemetry)
         self.sio.on('connect', self.connect)
 
+    def on_start(self):
         port = int(rospy.get_param('~uit_port', default=4567))
         hostname = rospy.get_param('~uit_hostname', default='127.0.0.1')
-        
-        self.listen = eventlet.listen((hostname, port))
+
         rospy.loginfo('Listening to %s:%d', hostname, port)
+
+        eventlet.wsgi.server(eventlet.listen((hostname, port)), self.app)
 
     def connect(self, sid, environ):
         rospy.loginfo('Connect to socket id: %s', sid)


### PR DESCRIPTION
This pull request includes:
- Fix bug between rospy and socket.
- Solve simulator set adapter to UITSimAdapter problem (if we run eventlet.wsgi.server in UITSimAdapter.__init__() the adapter will not be set to the simulator).